### PR TITLE
Fixing orortcCreateProgram function parameters

### DIFF
--- a/Orochi/OrochiUtils.cpp
+++ b/Orochi/OrochiUtils.cpp
@@ -471,7 +471,7 @@ oroFunction OrochiUtils::getFunction( oroDevice device, const char* code, const 
 	{
 		orortcProgram prog;
 		orortcResult e;
-		e = orortcCreateProgram( &prog, code, path, numHeaders, headers, includeNames );
+		e = orortcCreateProgram( &prog, code, funcName, numHeaders, headers, includeNames );
 		OROASSERT( e == ORORTC_SUCCESS, 0 );
 
 		e = orortcCompileProgram( prog, opts.size(), opts.data() );


### PR DESCRIPTION
I think this is a small mistake, because in the description of the `orortcCreateProgram ` API, instead of the path, there should be a function name.
Also if path is absolut this is the cause of ORORTC_ERROR_COMPILATION in `orortcCompileProgram`