### PR TITLE
Fix name caching

### DIFF
--- a/Orochi/OrochiUtils.cpp
+++ b/Orochi/OrochiUtils.cpp
@@ -371,6 +371,17 @@ struct OrochiUtilsImpl
 		return 0;
 	}
 
+	static std::string getCacheName( const std::string& path, const std::string& kernelname, std::vector<const char*>* opts ) noexcept
+	{
+		std::string tmp_name = path;
+		for( std::string s : *opts )
+		{
+			if( s.find( "-I" ) != std::string::npos ) continue;
+			tmp_name += s;
+		}
+		return tmp_name + kernelname;
+	}
+
 	static std::string getCacheName( const std::string& path, const std::string& kernelname ) noexcept { return path + kernelname; }
 };
 
@@ -384,7 +395,7 @@ oroFunction OrochiUtils::getFunctionFromFile( oroDevice device, const char* path
 {
 	std::lock_guard<std::recursive_mutex> lock( m_mutex );
 
-	const std::string cacheName = OrochiUtilsImpl::getCacheName( path, funcName );
+	const std::string cacheName = OrochiUtilsImpl::getCacheName( path, funcName, optsIn );
 	if( m_kernelMap.find( cacheName.c_str() ) != m_kernelMap.end() )
 	{
 		return m_kernelMap[cacheName];
@@ -402,7 +413,7 @@ oroFunction OrochiUtils::getFunctionFromString( oroDevice device, const char* so
 {
 	std::lock_guard<std::recursive_mutex> lock( m_mutex );
 
-	const std::string cacheName = OrochiUtilsImpl::getCacheName( path, funcName );
+	const std::string cacheName = OrochiUtilsImpl::getCacheName( path, funcName, optsIn );
 	if( m_kernelMap.find( cacheName.c_str() ) != m_kernelMap.end() )
 	{
 		return m_kernelMap[cacheName];

--- a/Orochi/OrochiUtils.cpp
+++ b/Orochi/OrochiUtils.cpp
@@ -373,13 +373,17 @@ struct OrochiUtilsImpl
 
 	static std::string getCacheName( const std::string& path, const std::string& kernelname, std::vector<const char*>* opts ) noexcept
 	{
-		std::string tmp_name = path;
+		std::string tmp_name = path + kernelname;
+
+		if (opts == nullptr)
+			return tmp_name;
+
 		for( std::string s : *opts )
 		{
-			if( s[0] == '-' && s[1] == 'I' ) continue;
+			if( s.size() > 1 && s[0] == '-' && s[1] == 'I' ) continue;
 			tmp_name += s;
 		}
-		return tmp_name + kernelname;
+		return tmp_name;
 	}
 
 	static std::string getCacheName( const std::string& path, const std::string& kernelname ) noexcept { return path + kernelname; }

--- a/Orochi/OrochiUtils.cpp
+++ b/Orochi/OrochiUtils.cpp
@@ -373,13 +373,17 @@ struct OrochiUtilsImpl
 
 	static std::string getCacheName( const std::string& path, const std::string& kernelname, std::vector<const char*>* opts ) noexcept
 	{
-		std::string tmp_name = path;
+		std::string tmp_name = path + kernelname;
+
+        if (opts == nullptr)
+            return tmp_name;
+
 		for( std::string s : *opts )
 		{
-			if( s[0] == '-' && s[1] == 'I' ) continue;
+			if( s.size() > 1 && s[0] == '-' && s[1] == 'I' ) continue;
 			tmp_name += s;
 		}
-		return tmp_name + kernelname;
+		return tmp_name;
 	}
 
 	static std::string getCacheName( const std::string& path, const std::string& kernelname ) noexcept { return path + kernelname; }

--- a/Orochi/OrochiUtils.cpp
+++ b/Orochi/OrochiUtils.cpp
@@ -376,7 +376,7 @@ struct OrochiUtilsImpl
 		std::string tmp_name = path;
 		for( std::string s : *opts )
 		{
-			if( s.find( "-I" ) != std::string::npos ) continue;
+			if( s[0] == '-' && s[1] == 'I' ) continue;
 			tmp_name += s;
 		}
 		return tmp_name + kernelname;

--- a/Orochi/OrochiUtils.cpp
+++ b/Orochi/OrochiUtils.cpp
@@ -375,13 +375,8 @@ struct OrochiUtilsImpl
 	{
 		std::string tmp_name = path + kernelname;
 
-<<<<<<< HEAD
 		if (opts == nullptr)
 			return tmp_name;
-=======
-        if (opts == nullptr)
-            return tmp_name;
->>>>>>> c349b2cad6808774cd9b611d0239f98276c1c052
 
 		for( std::string s : *opts )
 		{


### PR DESCRIPTION
Ability to generate different kernels based on compilation options. In some cases, the options may be different (such as definitions or constants), but the kernek logic is the same. In this case, the kernel must be recompiled.

PS: Sorry to add the previous PR's code to this (_Fix orortcCreateProgram param_). I can't set the previous PR's branch as the base repository, only the master. Therefore, the code of the last PR was added.