### PR TITLE
Radix sort update

### DIFF
--- a/ParallelPrimitives/RadixSort.cpp
+++ b/ParallelPrimitives/RadixSort.cpp
@@ -13,7 +13,7 @@
 // clang-format on
 #endif
 
-#if defined(__GNUC__)
+#if defined( __GNUC__ )
 #include <dlfcn.h>
 #endif
 
@@ -25,7 +25,7 @@ constexpr auto useBitCode = true;
 constexpr auto useBitCode = false;
 #endif
 
-#if !defined(__GNUC__)
+#if !defined( __GNUC__ )
 const HMODULE GetCurrentModule()
 {
 	HMODULE hModule = NULL;
@@ -34,12 +34,8 @@ const HMODULE GetCurrentModule()
 	return hModule;
 }
 #else
-void GetCurrentModule1()
-{
-}
+void GetCurrentModule1() {}
 #endif
-
-
 
 void printKernelInfo( oroFunction func )
 {
@@ -58,31 +54,19 @@ void printKernelInfo( oroFunction func )
 namespace Oro
 {
 
-RadixSort::RadixSort()
+RadixSort::RadixSort( oroDevice device, OrochiUtils& oroutils ) : m_device{ device }, m_oroutils{ oroutils }
 {
-	if( selectedScanAlgo == ScanAlgo::SCAN_GPU_PARALLEL )
-	{
-		m_partialSum.resize( m_nWGsToExecute );
-		OrochiUtils::malloc( m_isReady, m_nWGsToExecute );
-		OrochiUtils::memset( m_isReady, false, m_nWGsToExecute * sizeof( bool ) );
-	}
+	oroGetDeviceProperties( &m_props, device );
+	configure();
 }
 
-RadixSort::~RadixSort()
+void RadixSort::exclusiveScanCpu( const Oro::GpuMemory<int>& countsGpu, Oro::GpuMemory<int>& offsetsGpu, const int n_block_executed, oroStream stream ) noexcept
 {
-	if( selectedScanAlgo == ScanAlgo::SCAN_GPU_PARALLEL )
-	{
-		OrochiUtils::free( m_isReady );
-	}
-}
+	// The buffer size for count depends on how many GPU blocks are launched.
+	const auto buffer_size = Oro::BIN_SIZE * n_block_executed;
 
-void RadixSort::exclusiveScanCpu( int* countsGpu, int* offsetsGpu, const int nWGsToExecute, oroStream stream ) noexcept
-{
-	std::vector<int> counts( Oro::BIN_SIZE * nWGsToExecute );
-	OrochiUtils::copyDtoHAsync( counts.data(), countsGpu, Oro::BIN_SIZE * nWGsToExecute, stream );
-	OrochiUtils::waitForCompletion( stream );
-
-	std::vector<int> offsets( Oro::BIN_SIZE * nWGsToExecute );
+	std::vector<int> counts = countsGpu.getData();
+	std::vector<int> offsets( buffer_size );
 
 	int sum = 0;
 	for( int i = 0; i < counts.size(); ++i )
@@ -91,11 +75,10 @@ void RadixSort::exclusiveScanCpu( int* countsGpu, int* offsetsGpu, const int nWG
 		sum += counts[i];
 	}
 
-	OrochiUtils::copyHtoDAsync( offsetsGpu, offsets.data(), Oro::BIN_SIZE * nWGsToExecute, stream );
-	OrochiUtils::waitForCompletion( stream );
+	offsetsGpu.copyFromHost( offsets.data(), std::size( offsets ) );
 }
 
-void RadixSort::compileKernels( oroDevice device, OrochiUtils& oroutils, const std::string& kernelPath, const std::string& includeDir ) noexcept
+void RadixSort::compileKernels( const std::string& kernelPath, const std::string& includeDir ) noexcept
 {
 	constexpr auto defaultKernelPath{ "../ParallelPrimitives/RadixSortKernels.h" };
 	constexpr auto defaultIncludeDir{ "../" };
@@ -103,9 +86,9 @@ void RadixSort::compileKernels( oroDevice device, OrochiUtils& oroutils, const s
 	const auto currentKernelPath{ ( kernelPath == "" ) ? defaultKernelPath : kernelPath };
 	const auto currentIncludeDir{ ( includeDir == "" ) ? defaultIncludeDir : includeDir };
 
-	auto getCurrentDir = []()
+	const auto getCurrentDir = []() noexcept
 	{
-#if !defined(__GNUC__)
+#if !defined( __GNUC__ )
 		HMODULE hm = GetCurrentModule();
 		char buff[MAX_PATH];
 		GetModuleFileName( hm, buff, MAX_PATH );
@@ -113,28 +96,28 @@ void RadixSort::compileKernels( oroDevice device, OrochiUtils& oroutils, const s
 		Dl_info info;
 		dladdr( (const void*)GetCurrentModule1, &info );
 		const char* buff = info.dli_fname;
-#endif	
+#endif
 		std::string::size_type position = std::string( buff ).find_last_of( "\\/" );
 		return std::string( buff ).substr( 0, position ) + "/";
 	};
 
 	std::string binaryPath{};
+	std::string log{};
 	if constexpr( useBitCode )
 	{
 		const bool isAmd = oroGetCurAPI( 0 ) == ORO_API_HIP;
 		binaryPath = getCurrentDir();
 		binaryPath += isAmd ? "oro_compiled_kernels.hipfb" : "oro_compiled_kernels.fatbin";
-		if( m_flags == Flag::LOG )
-		{
-			std::cout << "loading pre-compiled kernels at path : " << binaryPath << '\n';
-		}
+		log = "loading pre-compiled kernels at path : " + binaryPath;
 	}
 	else
 	{
-		if( m_flags == Flag::LOG )
-		{
-			std::cout << "compiling kernels at path : " << currentKernelPath << " in : " << currentIncludeDir << '\n';
-		}
+		log = "compiling kernels at path : " + currentKernelPath + " in : " + currentIncludeDir;
+	}
+
+	if( m_flags == Flag::LOG )
+	{
+		std::cout << log << std::endl;
 	}
 
 	const auto includeArg{ "-I" + currentIncludeDir };
@@ -149,8 +132,8 @@ void RadixSort::compileKernels( oroDevice device, OrochiUtils& oroutils, const s
 	};
 
 	const std::vector<Record> records{
-		{ "CountKernel", Kernel::COUNT }, { "CountKernelReference", Kernel::COUNT_REF }, { "ParallelExclusiveScanSingleWG", Kernel::SCAN_SINGLE_WG }, { "ParallelExclusiveScanAllWG", Kernel::SCAN_PARALLEL },
-		{ "SortKernel", Kernel::SORT },	  { "SortKVKernel", Kernel::SORT_KV },			 { "SortSinglePassKernel", Kernel::SORT_SINGLE_PASS },		  { "SortSinglePassKVKernel", Kernel::SORT_SINGLE_PASS_KV },
+		{ "CountKernel", Kernel::COUNT },	 { "ParallelExclusiveScanSingleWG", Kernel::SCAN_SINGLE_WG }, { "ParallelExclusiveScanAllWG", Kernel::SCAN_PARALLEL },	 { "SortKernel", Kernel::SORT },
+		{ "SortKVKernel", Kernel::SORT_KV }, { "SortSinglePassKernel", Kernel::SORT_SINGLE_PASS },		  { "SortSinglePassKVKernel", Kernel::SORT_SINGLE_PASS_KV },
 	};
 
 	for( const auto& record : records )
@@ -161,12 +144,11 @@ void RadixSort::compileKernels( oroDevice device, OrochiUtils& oroutils, const s
 
 		if constexpr( useBitCode )
 		{
-			oroFunctions[record.kernelType] = oroutils.getFunctionFromPrecompiledBinary( binaryPath.c_str(), record.kernelName.c_str() );
+			oroFunctions[record.kernelType] = m_oroutils.getFunctionFromPrecompiledBinary( binaryPath.c_str(), record.kernelName.c_str() );
 		}
 		else
 		{
-
-			oroFunctions[record.kernelType] = oroutils.getFunctionFromFile( device, currentKernelPath.c_str(), record.kernelName.c_str(), &opts );
+			oroFunctions[record.kernelType] = m_oroutils.getFunctionFromFile( m_device, currentKernelPath.c_str(), record.kernelName.c_str(), &opts );
 		}
 
 #endif
@@ -177,44 +159,51 @@ void RadixSort::compileKernels( oroDevice device, OrochiUtils& oroutils, const s
 	}
 }
 
-int RadixSort::calculateWGsToExecute( oroDevice device ) noexcept
+int RadixSort::calculateWGsToExecute( const int blockSize ) noexcept
 {
-	oroDeviceProp props{};
-	oroGetDeviceProperties( &props, device );
+	constexpr auto default_warp_size = 32;
 
-	constexpr auto maxWGSize = std::max( { COUNT_WG_SIZE, SCAN_WG_SIZE, SORT_WG_SIZE } );
-	const int warpSize = ( props.warpSize != 0 ) ? props.warpSize : 32;
-	const int warpPerWG = maxWGSize / warpSize;
-	const int warpPerWGP = props.maxThreadsPerMultiProcessor / warpSize;
+	const int warpSize = ( m_props.warpSize != 0 ) ? m_props.warpSize : default_warp_size;
+	const int warpPerWG = blockSize / warpSize;
+	const int warpPerWGP = m_props.maxThreadsPerMultiProcessor / warpSize;
 	const int occupancyFromWarp = ( warpPerWGP > 0 ) ? ( warpPerWGP / warpPerWG ) : 1;
 
-	// From the runtime measurements this yields better result.
-	const int occupancy = std::max( 1, occupancyFromWarp / 2 );
+	const int occupancy = std::max( 1, occupancyFromWarp );
 
-	if( m_flags == Flag::LOG ) std::cout << "Occupancy: " << occupancy << '\n';
-
-	return props.multiProcessorCount * occupancy;
-}
-
-RadixSort::u32 RadixSort::configure( oroDevice device, OrochiUtils& oroutils, const std::string& kernelPath, const std::string& includeDir, oroStream stream ) noexcept
-{
-	compileKernels( device, oroutils, kernelPath, includeDir );
-	const auto newWGsToExecute{ calculateWGsToExecute( device ) };
-
-	if( newWGsToExecute != m_nWGsToExecute && selectedScanAlgo == ScanAlgo::SCAN_GPU_PARALLEL )
+	if( m_flags == Flag::LOG )
 	{
-		m_partialSum.resize( newWGsToExecute );
-		OrochiUtils::free( m_isReady );
-		OrochiUtils::malloc( m_isReady, newWGsToExecute );
-		OrochiUtils::memsetAsync( m_isReady, false, newWGsToExecute * sizeof( bool ), stream );
+		std::cout << "Occupancy: " << occupancy << '\n';
 	}
 
-	m_nWGsToExecute = newWGsToExecute;
-	return static_cast<u32>( BIN_SIZE * m_nWGsToExecute );
+	return m_props.multiProcessorCount * occupancy;
+}
+
+void RadixSort::configure( const std::string& kernelPath, const std::string& includeDir, oroStream stream ) noexcept
+{
+	compileKernels( kernelPath, includeDir );
+
+	m_num_blocks_for_count = calculateWGsToExecute( COUNT_WG_SIZE );
+
+	/// The tmp buffer size of the count kernel and the scan kernel.
+
+	const auto tmp_buffer_size = BIN_SIZE * m_num_blocks_for_count;
+
+	/// @c tmp_buffer_size must be dividable by @c SCAN_WG_SIZE
+
+	m_num_blocks_for_scan = tmp_buffer_size / SCAN_WG_SIZE;
+
+	m_tmp_buffer.resize( tmp_buffer_size );
+
+	if( selectedScanAlgo == ScanAlgo::SCAN_GPU_PARALLEL )
+	{
+		// These are for the scan kernel
+		m_partial_sum.resize( m_num_blocks_for_scan );
+		m_is_ready.resize( m_num_blocks_for_scan );
+	}
 }
 void RadixSort::setFlag( Flag flag ) noexcept { m_flags = flag; }
 
-void RadixSort::sort( const KeyValueSoA src, const KeyValueSoA dst, int n, int startBit, int endBit, u32* tempBuffer, oroStream stream ) noexcept
+void RadixSort::sort( const KeyValueSoA src, const KeyValueSoA dst, int n, int startBit, int endBit, oroStream stream ) noexcept
 {
 	// todo. better to compute SINGLE_SORT_N_ITEMS_PER_WI which we use in the kernel dynamically rather than hard coding it to distribute the work evenly
 	// right now, setting this as large as possible is faster than multi pass sorting
@@ -231,7 +220,7 @@ void RadixSort::sort( const KeyValueSoA src, const KeyValueSoA dst, int n, int s
 
 	for( int i = startBit; i < endBit; i += N_RADIX )
 	{
-		sort1pass( *s, *d, n, i, i + std::min( N_RADIX, endBit - i ), (int*)tempBuffer, stream );
+		sort1pass( *s, *d, n, i, i + std::min( N_RADIX, endBit - i ), stream );
 
 		std::swap( s, d );
 	}
@@ -243,7 +232,7 @@ void RadixSort::sort( const KeyValueSoA src, const KeyValueSoA dst, int n, int s
 	}
 }
 
-void RadixSort::sort( const u32* src, const u32* dst, int n, int startBit, int endBit, u32* tempBuffer, oroStream stream ) noexcept
+void RadixSort::sort( const u32* src, const u32* dst, int n, int startBit, int endBit, oroStream stream ) noexcept
 {
 	// todo. better to compute SINGLE_SORT_N_ITEMS_PER_WI which we use in the kernel dynamically rather than hard coding it to distribute the work evenly
 	// right now, setting this as large as possible is faster than multi pass sorting
@@ -260,7 +249,7 @@ void RadixSort::sort( const u32* src, const u32* dst, int n, int startBit, int e
 
 	for( int i = startBit; i < endBit; i += N_RADIX )
 	{
-		sort1pass( *s, *d, n, i, i + std::min( N_RADIX, endBit - i ), (int*)tempBuffer, stream );
+		sort1pass( *s, *d, n, i, i + std::min( N_RADIX, endBit - i ), stream );
 
 		std::swap( s, d );
 	}

--- a/ParallelPrimitives/RadixSort.cpp
+++ b/ParallelPrimitives/RadixSort.cpp
@@ -60,7 +60,7 @@ RadixSort::RadixSort( oroDevice device, OrochiUtils& oroutils ) : m_device{ devi
 	configure();
 }
 
-void RadixSort::exclusiveScanCpu( const Oro::GpuMemory<int>& countsGpu, Oro::GpuMemory<int>& offsetsGpu, const int n_block_executed, oroStream stream ) noexcept
+void RadixSort::exclusiveScanCpu( const Oro::GpuMemory<int>& countsGpu, Oro::GpuMemory<int>& offsetsGpu, const int n_block_executed, oroStream stream ) const noexcept
 {
 	// The buffer size for count depends on how many GPU blocks are launched.
 	const auto buffer_size = Oro::BIN_SIZE * n_block_executed;
@@ -159,7 +159,7 @@ void RadixSort::compileKernels( const std::string& kernelPath, const std::string
 	}
 }
 
-int RadixSort::calculateWGsToExecute( const int blockSize ) noexcept
+int RadixSort::calculateWGsToExecute( const int blockSize ) const noexcept
 {
 	constexpr auto default_warp_size = 32;
 

--- a/ParallelPrimitives/RadixSort.h
+++ b/ParallelPrimitives/RadixSort.h
@@ -10,12 +10,10 @@
 #include <string>
 #include <unordered_map>
 
-// #define PROFILE 1
-
 namespace Oro
 {
 
-class RadixSort
+class RadixSort final
 {
   public:
 	using u32 = uint32_t;
@@ -33,55 +31,56 @@ class RadixSort
 		LOG,
 	};
 
-	RadixSort();
+	RadixSort( oroDevice device, OrochiUtils& oroutils );
 
 	// Allow move but disallow copy.
 	RadixSort( RadixSort&& ) noexcept = default;
 	RadixSort& operator=( RadixSort&& ) noexcept = default;
 	RadixSort( const RadixSort& ) = delete;
 	RadixSort& operator=( const RadixSort& ) = delete;
-	~RadixSort();
-
-	/// @brief Configure the settings, compile the kernels and allocate the memory.
-	/// @param device The device.
-	/// @param kernelPath The kernel path.
-	/// @param includeDir The include directory.
-	/// @return The size of the temp buffer.
-	u32 configure( oroDevice device, OrochiUtils& oroutils, const std::string& kernelPath = "", const std::string& includeDir = "", oroStream stream = 0 ) noexcept;
+	~RadixSort() = default;
 
 	void setFlag( Flag flag ) noexcept;
 
-	void sort( const KeyValueSoA src, const KeyValueSoA dst, int n, int startBit, int endBit, u32* tempBuffer, oroStream stream = 0 ) noexcept;
+	void sort( const KeyValueSoA src, const KeyValueSoA dst, int n, int startBit, int endBit, oroStream stream = 0 ) noexcept;
 
-	void sort( const u32* src, const u32* dst, int n, int startBit, int endBit, u32* tempBuffer, oroStream stream = 0 ) noexcept;
+	void sort( const u32* src, const u32* dst, int n, int startBit, int endBit, oroStream stream = 0 ) noexcept;
 
   private:
 	template<class T>
-	void sort1pass( const T src, const T dst, int n, int startBit, int endBit, int* temps, oroStream stream ) noexcept;
+	void sort1pass( const T src, const T dst, int n, int startBit, int endBit, oroStream stream ) noexcept;
 
 	/// @brief Compile the kernels for radix sort.
-	/// @param device The device.
 	/// @param kernelPath The kernel path.
 	/// @param includeDir The include directory.
-	void compileKernels( oroDevice device, OrochiUtils& oroutils, const std::string& kernelPath, const std::string& includeDir ) noexcept;
+	void compileKernels( const std::string& kernelPath, const std::string& includeDir ) noexcept;
 
-	int calculateWGsToExecute( oroDevice device ) noexcept;
+	int calculateWGsToExecute( const int blockSize ) noexcept;
 
 	/// @brief Exclusive scan algorithm on CPU for testing.
 	/// It copies the count result from the Device to Host before computation, and then copies the offsets back from Host to Device afterward.
 	/// @param countsGpu The count result in GPU memory. Otuput: The offset.
 	/// @param offsetsGpu The offsets.
-	/// @param nWGsToExecute Number of WGs to execute
-	void exclusiveScanCpu( int* countsGpu, int* offsetsGpu, const int nWGsToExecute, oroStream stream ) noexcept;
+	/// @param n_block_executed Number of GPU blocks to execute
+	void exclusiveScanCpu( const Oro::GpuMemory<int>& countsGpu, Oro::GpuMemory<int>& offsetsGpu, const int n_block_executed, oroStream stream ) noexcept;
+
+	/// @brief Configure the settings, compile the kernels and allocate the memory.
+	/// @param kernelPath The kernel path.
+	/// @param includeDir The include directory.
+	void configure( const std::string& kernelPath = "", const std::string& includeDir = "", oroStream stream = 0 ) noexcept;
 
   private:
-	int m_nWGsToExecute{ 4 };
+	// GPU blocks for the count kernel
+	int m_num_blocks_for_count{};
+
+	// GPU blocks for the scan kernel
+	int m_num_blocks_for_scan{};
+
 	Flag m_flags{ Flag::NO_LOG };
 
 	enum class Kernel
 	{
 		COUNT,
-		COUNT_REF,
 		SCAN_SINGLE_WG,
 		SCAN_PARALLEL,
 		SORT,
@@ -102,8 +101,16 @@ class RadixSort
 
 	constexpr static auto selectedScanAlgo{ ScanAlgo::SCAN_GPU_PARALLEL };
 
-	GpuMemory<int> m_partialSum;
-	bool* m_isReady{ nullptr };
+	GpuMemory<int> m_partial_sum;
+	GpuMemory<bool> m_is_ready;
+
+	oroDevice m_device{};
+	oroDeviceProp m_props{};
+
+	OrochiUtils& m_oroutils;
+
+	// This buffer holds the "bucket" table from all GPU blocks.
+	GpuMemory<int> m_tmp_buffer;
 };
 
 #include <ParallelPrimitives/RadixSort.inl>

--- a/ParallelPrimitives/RadixSort.h
+++ b/ParallelPrimitives/RadixSort.h
@@ -55,14 +55,14 @@ class RadixSort final
 	/// @param includeDir The include directory.
 	void compileKernels( const std::string& kernelPath, const std::string& includeDir ) noexcept;
 
-	int calculateWGsToExecute( const int blockSize ) noexcept;
+	int calculateWGsToExecute( const int blockSize ) const noexcept;
 
 	/// @brief Exclusive scan algorithm on CPU for testing.
 	/// It copies the count result from the Device to Host before computation, and then copies the offsets back from Host to Device afterward.
 	/// @param countsGpu The count result in GPU memory. Otuput: The offset.
 	/// @param offsetsGpu The offsets.
 	/// @param n_block_executed Number of GPU blocks to execute
-	void exclusiveScanCpu( const Oro::GpuMemory<int>& countsGpu, Oro::GpuMemory<int>& offsetsGpu, const int n_block_executed, oroStream stream ) noexcept;
+	void exclusiveScanCpu( const Oro::GpuMemory<int>& countsGpu, Oro::GpuMemory<int>& offsetsGpu, const int n_block_executed, oroStream stream ) const noexcept;
 
 	/// @brief Configure the settings, compile the kernels and allocate the memory.
 	/// @param kernelPath The kernel path.

--- a/ParallelPrimitives/RadixSort.inl
+++ b/ParallelPrimitives/RadixSort.inl
@@ -1,9 +1,9 @@
 
 
 template<class T>
-void RadixSort::sort1pass( const T src, const T dst, int n, int startBit, int endBit, int* temps, oroStream stream ) noexcept
+void RadixSort::sort1pass( const T src, const T dst, int n, int startBit, int endBit, oroStream stream ) noexcept
 {
-	constexpr bool reference = false;
+	constexpr auto enable_profile = false;
 
 	const u32* srcKey{ nullptr };
 	const u32* dstKey{ nullptr };
@@ -28,39 +28,41 @@ void RadixSort::sort1pass( const T src, const T dst, int n, int startBit, int en
 		dstKey = dst;
 	}
 
-	// allocate temps
-	// clear temps
-	// count kernel
-	// scan
-	// sort
-
-	const int nWIs = WG_SIZE * m_nWGsToExecute;
+	const int nWIs = WG_SIZE * m_num_blocks_for_count;
 	int nItemsPerWI = ( n + ( nWIs - 1 ) ) / nWIs;
 
 	// Adjust nItemsPerWI to be dividable by SORT_N_ITEMS_PER_WI.
 	nItemsPerWI = ( std::ceil( static_cast<double>( nItemsPerWI ) / SORT_N_ITEMS_PER_WI ) ) * SORT_N_ITEMS_PER_WI;
 
-	int nItemPerWG = nItemsPerWI * WG_SIZE;
+	const int nItemPerWG = nItemsPerWI * WG_SIZE;
 
 	if( m_flags == Flag::LOG )
 	{
-		printf( "nWGs: %d\n", m_nWGsToExecute );
+		printf( "num_blocks_for_count: %d\n", m_num_blocks_for_count );
+		printf( "num_blocks_for_scan: %d\n", m_num_blocks_for_scan );
 		printf( "nNItemsPerWI: %d\n", nItemsPerWI );
 		printf( "nItemPerWG: %d\n", nItemPerWG );
+
+		std::cout << "Input size n: " << n << std::endl;
 	}
 
 	float t[3] = { 0.f };
+
 	{
+		const auto num_total_thread_for_count = COUNT_WG_SIZE * m_num_blocks_for_count;
+
 		Stopwatch sw;
 		sw.start();
-		const auto func{ reference ? oroFunctions[Kernel::COUNT_REF] : oroFunctions[Kernel::COUNT] };
-		const void* args[] = { &srcKey, &temps, &n, &nItemPerWG, &startBit, &m_nWGsToExecute };
-		OrochiUtils::launch1D( func, COUNT_WG_SIZE * m_nWGsToExecute, args, COUNT_WG_SIZE, 0, stream );
-#if defined( PROFILE )
-		OrochiUtils::waitForCompletion( stream );
-		sw.stop();
-		t[0] = sw.getMs();
-#endif
+		const auto func{ oroFunctions[Kernel::COUNT] };
+		const void* args[] = { &srcKey, arg_cast( m_tmp_buffer.address() ), &n, &nItemPerWG, &startBit, &m_num_blocks_for_count };
+		OrochiUtils::launch1D( func, num_total_thread_for_count, args, COUNT_WG_SIZE, 0, stream );
+
+		if constexpr( enable_profile )
+		{
+			OrochiUtils::waitForCompletion( stream );
+			sw.stop();
+			t[0] = sw.getMs();
+		}
 	}
 
 	{
@@ -70,57 +72,67 @@ void RadixSort::sort1pass( const T src, const T dst, int n, int startBit, int en
 		{
 		case ScanAlgo::SCAN_CPU:
 		{
-			exclusiveScanCpu( temps, temps, m_nWGsToExecute, stream );
+			exclusiveScanCpu( m_tmp_buffer, m_tmp_buffer, m_num_blocks_for_count, stream );
 		}
 		break;
 
 		case ScanAlgo::SCAN_GPU_SINGLE_WG:
 		{
-			const void* args[] = { &temps, &temps, &m_nWGsToExecute };
-			OrochiUtils::launch1D( oroFunctions[Kernel::SCAN_SINGLE_WG], WG_SIZE * m_nWGsToExecute, args, WG_SIZE, 0, stream );
+			const void* args[] = { arg_cast( m_tmp_buffer.address() ), arg_cast( m_tmp_buffer.address() ), &m_num_blocks_for_count };
+			OrochiUtils::launch1D( oroFunctions[Kernel::SCAN_SINGLE_WG], WG_SIZE * m_num_blocks_for_count, args, WG_SIZE, 0, stream );
 		}
 		break;
 
 		case ScanAlgo::SCAN_GPU_PARALLEL:
 		{
-			const void* args[] = { &temps, &temps, arg_cast( m_partialSum.address() ), &m_isReady };
-			OrochiUtils::launch1D( oroFunctions[Kernel::SCAN_PARALLEL], SCAN_WG_SIZE * m_nWGsToExecute, args, SCAN_WG_SIZE, 0, stream );
+			const auto num_total_thread_for_scan = SCAN_WG_SIZE * m_num_blocks_for_scan;
+
+			const void* args[] = { arg_cast( m_tmp_buffer.address() ), arg_cast( m_tmp_buffer.address() ), arg_cast( m_partial_sum.address() ), arg_cast( m_is_ready.address() ) };
+			OrochiUtils::launch1D( oroFunctions[Kernel::SCAN_PARALLEL], num_total_thread_for_scan, args, SCAN_WG_SIZE, 0, stream );
 		}
 		break;
 
 		default:
-			exclusiveScanCpu( temps, temps, m_nWGsToExecute, stream );
+			exclusiveScanCpu( m_tmp_buffer, m_tmp_buffer, m_num_blocks_for_count, stream );
 			break;
 		}
-#if defined( PROFILE )
-		OrochiUtils::waitForCompletion( stream );
-		sw.stop();
-		t[1] = sw.getMs();
-#endif
+
+		if constexpr( enable_profile )
+		{
+			OrochiUtils::waitForCompletion( stream );
+			sw.stop();
+			t[1] = sw.getMs();
+		}
 	}
 
 	{
 		Stopwatch sw;
 		sw.start();
 
+		const auto num_blocks_for_sort = m_num_blocks_for_count;
+		const auto num_total_thread_for_sort = SORT_WG_SIZE * num_blocks_for_sort;
+
 		if constexpr( keyValuePairedEnabled )
 		{
-			const void* args[] = { &srcKey, &srcVal, &dstKey, &dstVal, &temps, &n, &nItemsPerWI, &startBit, &m_nWGsToExecute };
-			OrochiUtils::launch1D( oroFunctions[Kernel::SORT_KV], SORT_WG_SIZE * m_nWGsToExecute, args, SORT_WG_SIZE, 0, stream );
+			const void* args[] = { &srcKey, &srcVal, &dstKey, &dstVal, arg_cast( m_tmp_buffer.address() ), &n, &nItemsPerWI, &startBit, &num_blocks_for_sort };
+			OrochiUtils::launch1D( oroFunctions[Kernel::SORT_KV], num_total_thread_for_sort, args, SORT_WG_SIZE, 0, stream );
 		}
 		else
 		{
-			const void* args[] = { &srcKey, &dstKey, &temps, &n, &nItemsPerWI, &startBit, &m_nWGsToExecute };
-			OrochiUtils::launch1D( oroFunctions[Kernel::SORT], SORT_WG_SIZE * m_nWGsToExecute, args, SORT_WG_SIZE, 0, stream );
+			const void* args[] = { &srcKey, &dstKey, arg_cast( m_tmp_buffer.address() ), &n, &nItemsPerWI, &startBit, &num_blocks_for_sort };
+			OrochiUtils::launch1D( oroFunctions[Kernel::SORT], num_total_thread_for_sort, args, SORT_WG_SIZE, 0, stream );
 		}
 
-#if defined( PROFILE )
-		OrochiUtils::waitForCompletion( stream );
-		sw.stop();
-		t[2] = sw.getMs();
-#endif
+		if constexpr( enable_profile )
+		{
+			OrochiUtils::waitForCompletion( stream );
+			sw.stop();
+			t[2] = sw.getMs();
+		}
 	}
-#if defined( PROFILE )
-	printf( "%3.2f, %3.2f, %3.2f\n", t[0], t[1], t[2] );
-#endif
+
+	if constexpr( enable_profile )
+	{
+		printf( "%3.2f, %3.2f, %3.2f\n", t[0], t[1], t[2] );
+	}
 }

--- a/ParallelPrimitives/RadixSortConfigs.h
+++ b/ParallelPrimitives/RadixSortConfigs.h
@@ -16,9 +16,15 @@ constexpr auto N_BINS_PACK_FACTOR{ sizeof( long long ) / sizeof( short ) };
 constexpr auto N_BINS_PACKED_4BIT{ N_BINS_4BIT / N_BINS_PACK_FACTOR };
 
 constexpr auto N_BINS_8BIT{ 1 << 8 };
+
+constexpr auto DEFAULT_WARP_SIZE{ 32 };
+
 // count config
 
-constexpr auto COUNT_WG_SIZE{ BIN_SIZE };
+constexpr auto COUNT_WG_SIZE{ DEFAULT_WARP_SIZE * 8 };
+
+// scan configs
+constexpr auto SCAN_WG_SIZE{ DEFAULT_WARP_SIZE * 8 };
 
 // sort configs
 constexpr auto SORT_WG_SIZE{ 64 };
@@ -26,7 +32,11 @@ constexpr auto SORT_N_ITEMS_PER_WI{ 12 };
 constexpr auto SINGLE_SORT_N_ITEMS_PER_WI{ 24 };
 constexpr auto SINGLE_SORT_WG_SIZE{ 128 };
 
-// scan configs
-constexpr auto SCAN_WG_SIZE{ BIN_SIZE };
+
+// Checks
+
+
+// The gpu block size for scan cannot exceed the bin size due to how the total number of threads is calculated
+static_assert( BIN_SIZE % SCAN_WG_SIZE == 0 );
 
 }; // namespace Oro

--- a/ParallelPrimitives/RadixSortKernels.h
+++ b/ParallelPrimitives/RadixSortKernels.h
@@ -1,15 +1,18 @@
 #include <ParallelPrimitives/RadixSortConfigs.h>
 #define LDS_BARRIER __syncthreads()
 
+namespace
+{
+
 using namespace Oro;
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef unsigned long long u64;
+
+using u8 = unsigned char;
+using u16 = unsigned short;
+using u32 = unsigned int;
+using u64 = unsigned long long;
+} // namespace
 
 // #define NV_WORKAROUND 1
-
-#define THE_FIRST_THREAD threadIdx.x == 0 && blockIdx.x == 0
 
 extern "C" __global__ void CountKernelReference( int* gSrc, int* gDst, int gN, int gNItemsPerWI, const int START_BIT, const int N_WGS_EXECUTED )
 {
@@ -62,8 +65,10 @@ extern "C" __global__ void CountKernel( int* gSrc, int* gDst, int gN, int gNItem
 
 	LDS_BARRIER;
 
-	// Assume COUNT_WG_SIZE == BIN_SIZE
-	gDst[threadIdx.x * N_WGS_EXECUTED + blockIdx.x] = table[threadIdx.x];
+	for( int i = threadIdx.x; i < BIN_SIZE; i += COUNT_WG_SIZE )
+	{
+		gDst[i * N_WGS_EXECUTED + blockIdx.x] = table[i];
+	}
 }
 
 template<typename T, int STRIDE>

--- a/Test/RadixSort/main.cpp
+++ b/Test/RadixSort/main.cpp
@@ -52,10 +52,8 @@ using u32 = Oro::RadixSort::u32;
 class SortTest
 {
   public:
-	SortTest( oroDevice dev, oroCtx ctx, OrochiUtils& oroutils ) : m_device( dev ), m_ctx( ctx )
+	SortTest( oroDevice dev, oroCtx ctx, OrochiUtils& oroutils ) : m_device( dev ), m_ctx( ctx ), m_sort(dev, oroutils)
 	{
-		const auto s = m_sort.configure( m_device, oroutils );
-		OrochiUtils::malloc( m_tempBuffer, s );
 	}
 
 	~SortTest() { OrochiUtils::free( m_tempBuffer ); }
@@ -104,11 +102,11 @@ class SortTest
 
 			if constexpr( KEY_VALUE_PAIR )
 			{
-				m_sort.sort( srcGpu, dstGpu, testSize, 0, testBits, m_tempBuffer );
+				m_sort.sort( srcGpu, dstGpu, testSize, 0, testBits);
 			}
 			else
 			{
-				m_sort.sort( srcGpu.key, dstGpu.key, testSize, 0, testBits, m_tempBuffer );
+				m_sort.sort( srcGpu.key, dstGpu.key, testSize, 0, testBits );
 			}
 
 			OrochiUtils::waitForCompletion();


### PR DESCRIPTION
This PR implements the followings:

- Refactor Count
- Replace preprocessors with `if constexpr`
- Now the tmp buffer for count and sort is allocated internally.
- All GPU memory buffers are changed to the `GpuMemory` class
- `configure` will now calculate the total number of GPU blocks for the count and the scan kernel
- The client does not need to call configure explicitly
- Refactor function parameters
- Remove count reference kernel
