### PR TITLE
Radix sort bugfix reset and add subblock

### DIFF
--- a/ParallelPrimitives/RadixSort.cpp
+++ b/ParallelPrimitives/RadixSort.cpp
@@ -139,22 +139,6 @@ void RadixSort::compileKernels( const std::string& kernelPath, const std::string
 		std::cout << log << std::endl;
 	}
 
-	const auto includeArg{ "-I" + currentIncludeDir };
-	const auto overwrite_flag = "-DOVERWRITE";
-	const auto count_block_size_param = "-DCOUNT_WG_SIZE_VAL=" + std::to_string( m_num_threads_per_block_for_count );
-	const auto scan_block_size_param = "-DSCAN_WG_SIZE_VAL=" + std::to_string( m_num_threads_per_block_for_scan );
-	const auto sort_block_size_param = "-DSORT_WG_SIZE_VAL=" + std::to_string( m_num_threads_per_block_for_sort );
-	const auto sort_num_warps_param = "-DSORT_NUM_WARPS_PER_BLOCK_VAL=" + std::to_string( m_num_warps_per_block_for_sort );
-
-	std::vector<const char*> opts;
-	opts.push_back( "-ffast-math" );
-	opts.push_back( includeArg.c_str() );
-	opts.push_back( overwrite_flag );
-	opts.push_back( count_block_size_param.c_str() );
-	opts.push_back( scan_block_size_param.c_str() );
-	opts.push_back( sort_block_size_param.c_str() );
-	opts.push_back( sort_num_warps_param.c_str() );
-
 	struct Record
 	{
 		std::string kernelName;
@@ -178,6 +162,22 @@ void RadixSort::compileKernels( const std::string& kernelPath, const std::string
 		}
 		else
 		{
+			const auto includeArg{ "-I" + currentIncludeDir };
+			const auto overwrite_flag = "-DOVERWRITE";
+			const auto count_block_size_param = "-DCOUNT_WG_SIZE_VAL=" + std::to_string( m_num_threads_per_block_for_count );
+			const auto scan_block_size_param = "-DSCAN_WG_SIZE_VAL=" + std::to_string( m_num_threads_per_block_for_scan );
+			const auto sort_block_size_param = "-DSORT_WG_SIZE_VAL=" + std::to_string( m_num_threads_per_block_for_sort );
+			const auto sort_num_warps_param = "-DSORT_NUM_WARPS_PER_BLOCK_VAL=" + std::to_string( m_num_warps_per_block_for_sort );
+
+			std::vector<const char*> opts;
+			opts.push_back( "-ffast-math" );
+			opts.push_back( includeArg.c_str() );
+			opts.push_back( overwrite_flag );
+			opts.push_back( count_block_size_param.c_str() );
+			opts.push_back( scan_block_size_param.c_str() );
+			opts.push_back( sort_block_size_param.c_str() );
+			opts.push_back( sort_num_warps_param.c_str() );
+
 			oroFunctions[record.kernelType] = m_oroutils.getFunctionFromFile( m_device, currentKernelPath.c_str(), record.kernelName.c_str(), &opts );
 		}
 

--- a/ParallelPrimitives/RadixSort.cpp
+++ b/ParallelPrimitives/RadixSort.cpp
@@ -239,6 +239,7 @@ void RadixSort::configure( const std::string& kernelPath, const std::string& inc
 		// These are for the scan kernel
 		m_partial_sum.resize( m_num_blocks_for_scan );
 		m_is_ready.resize( m_num_blocks_for_scan );
+		m_is_ready.reset();
 	}
 }
 void RadixSort::setFlag( Flag flag ) noexcept { m_flags = flag; }

--- a/ParallelPrimitives/RadixSort.cpp
+++ b/ParallelPrimitives/RadixSort.cpp
@@ -127,9 +127,9 @@ void RadixSort::compileKernels( const std::string& kernelPath, const std::string
 
 		m_warp_size = ( m_props.warpSize != 0 ) ? m_props.warpSize : DEFAULT_WARP_SIZE;
 
-		assert( m_num_threads_per_block_for_count % warp_size == 0 );
-		assert( m_num_threads_per_block_for_scan % warp_size == 0 );
-		assert( m_num_threads_per_block_for_sort % warp_size == 0 );
+		assert( m_num_threads_per_block_for_count % m_warp_size == 0 );
+		assert( m_num_threads_per_block_for_scan % m_warp_size == 0 );
+		assert( m_num_threads_per_block_for_sort % m_warp_size == 0 );
 	}
 
 	m_num_warps_per_block_for_sort = m_num_threads_per_block_for_sort / m_warp_size;
@@ -147,7 +147,7 @@ void RadixSort::compileKernels( const std::string& kernelPath, const std::string
 	const auto sort_num_warps_param = "-DSORT_NUM_WARPS_PER_BLOCK_VAL=" + std::to_string( m_num_warps_per_block_for_sort );
 
 	std::vector<const char*> opts;
-	opts.push_back("-ffast-math");
+	opts.push_back( "-ffast-math" );
 	opts.push_back( includeArg.c_str() );
 	opts.push_back( overwrite_flag );
 	opts.push_back( count_block_size_param.c_str() );

--- a/ParallelPrimitives/RadixSort.cpp
+++ b/ParallelPrimitives/RadixSort.cpp
@@ -115,9 +115,7 @@ void RadixSort::compileKernels( const std::string& kernelPath, const std::string
 		m_num_threads_per_block_for_scan = DEFAULT_SCAN_BLOCK_SIZE;
 		m_num_threads_per_block_for_sort = DEFAULT_SORT_BLOCK_SIZE;
 
-		const auto warp_size = DEFAULT_WARP_SIZE;
-
-		m_num_warps_per_block_for_sort = m_num_threads_per_block_for_sort / warp_size;
+		m_warp_size = DEFAULT_WARP_SIZE;
 	}
 	else
 	{
@@ -127,14 +125,14 @@ void RadixSort::compileKernels( const std::string& kernelPath, const std::string
 		m_num_threads_per_block_for_scan = m_props.maxThreadsPerBlock > 0 ? m_props.maxThreadsPerBlock : DEFAULT_SCAN_BLOCK_SIZE;
 		m_num_threads_per_block_for_sort = m_props.maxThreadsPerBlock > 0 ? m_props.maxThreadsPerBlock : DEFAULT_SORT_BLOCK_SIZE;
 
-		const auto warp_size = ( m_props.warpSize != 0 ) ? m_props.warpSize : DEFAULT_WARP_SIZE;
-
-		m_num_warps_per_block_for_sort = m_num_threads_per_block_for_sort / warp_size;
+		m_warp_size = ( m_props.warpSize != 0 ) ? m_props.warpSize : DEFAULT_WARP_SIZE;
 
 		assert( m_num_threads_per_block_for_count % warp_size == 0 );
 		assert( m_num_threads_per_block_for_scan % warp_size == 0 );
 		assert( m_num_threads_per_block_for_sort % warp_size == 0 );
 	}
+
+	m_num_warps_per_block_for_sort = m_num_threads_per_block_for_sort / m_warp_size;
 
 	if( m_flags == Flag::LOG )
 	{
@@ -149,6 +147,7 @@ void RadixSort::compileKernels( const std::string& kernelPath, const std::string
 	const auto sort_num_warps_param = "-DSORT_NUM_WARPS_PER_BLOCK_VAL=" + std::to_string( m_num_warps_per_block_for_sort );
 
 	std::vector<const char*> opts;
+	opts.push_back("-ffast-math");
 	opts.push_back( includeArg.c_str() );
 	opts.push_back( overwrite_flag );
 	opts.push_back( count_block_size_param.c_str() );
@@ -192,9 +191,8 @@ void RadixSort::compileKernels( const std::string& kernelPath, const std::string
 
 int RadixSort::calculateWGsToExecute( const int blockSize ) const noexcept
 {
-	const int warpSize = ( m_props.warpSize != 0 ) ? m_props.warpSize : DEFAULT_WARP_SIZE;
-	const int warpPerWG = blockSize / warpSize;
-	const int warpPerWGP = m_props.maxThreadsPerMultiProcessor / warpSize;
+	const int warpPerWG = blockSize / m_warp_size;
+	const int warpPerWGP = m_props.maxThreadsPerMultiProcessor / m_warp_size;
 	const int occupancyFromWarp = ( warpPerWGP > 0 ) ? ( warpPerWGP / warpPerWG ) : 1;
 
 	const int occupancy = std::max( 1, occupancyFromWarp );

--- a/ParallelPrimitives/RadixSort.h
+++ b/ParallelPrimitives/RadixSort.h
@@ -117,6 +117,8 @@ class RadixSort final
 	int m_num_threads_per_block_for_sort{};
 
 	int m_num_warps_per_block_for_sort{};
+
+	int m_warp_size{};
 };
 
 #include <ParallelPrimitives/RadixSort.inl>

--- a/ParallelPrimitives/RadixSortKernels.h
+++ b/ParallelPrimitives/RadixSortKernels.h
@@ -31,6 +31,13 @@ constexpr auto SORT_NUM_WARPS_PER_BLOCK{ DEFAULT_NUM_WARPS_PER_BLOCK };
 
 #endif
 
+#if defined( __CUDACC__ )
+constexpr int SORT_SUBBLOCK_SIZE = 2048;
+#else
+constexpr int SORT_SUBBLOCK_SIZE = 4096;
+#endif
+
+
 __device__ constexpr u32 getMaskedBits( const u32 value, const u32 shift ) noexcept { return ( value >> shift ) & RADIX_MASK; }
 
 extern "C" __global__ void CountKernel( int* gSrc, int* gDst, int gN, int gNItemsPerWG, const int START_BIT, const int N_WGS_EXECUTED )
@@ -635,19 +642,27 @@ extern "C" __global__ void ParallelExclusiveScanAllWG( int* gCount, int* gHistog
 template<bool KEY_VALUE_PAIR>
 __device__ void SortImpl( int* gSrcKey, int* gSrcVal, int* gDstKey, int* gDstVal, int* gHistogram, int numberOfInputs, int gNItemsPerWG, const int START_BIT, const int N_WGS_EXECUTED )
 {
+	const int startOffset = blockIdx.x * gNItemsPerWG;
+	const int nItemInBlock = ( startOffset + gNItemsPerWG > numberOfInputs ) ? numberOfInputs - startOffset : gNItemsPerWG;
+
+	struct ElementLocation
+	{
+		u32 localSrcIndex : 12;
+		u32 localOffset : 12;
+		u32 bucket : 8;
+	};
+
 	__shared__ u32 globalOffset[BIN_SIZE];
 	__shared__ u32 localPrefixSum[BIN_SIZE];
 	__shared__ u32 counters[BIN_SIZE];
-
 	__shared__ u32 matchMasks[SORT_NUM_WARPS_PER_BLOCK][BIN_SIZE];
+	__shared__ u8 elementBuckets[SORT_SUBBLOCK_SIZE];
+	__shared__ ElementLocation elementLocations[SORT_SUBBLOCK_SIZE];
 
 	for( int i = threadIdx.x; i < BIN_SIZE; i += SORT_WG_SIZE )
 	{
 		// Note: The size of gHistogram is always BIN_SIZE * N_WGS_EXECUTED
 		globalOffset[i] = gHistogram[i * N_WGS_EXECUTED + blockIdx.x];
-
-		counters[i] = 0;
-		localPrefixSum[i] = 0;
 	}
 
 	for( int w = 0; w < SORT_NUM_WARPS_PER_BLOCK; ++w )
@@ -660,93 +675,115 @@ __device__ void SortImpl( int* gSrcKey, int* gSrcVal, int* gDstKey, int* gDstVal
 
 	__syncthreads();
 
-	for( int i = threadIdx.x; i < gNItemsPerWG; i += SORT_WG_SIZE )
+	for( int j = 0; j < nItemInBlock; j += SORT_SUBBLOCK_SIZE )
 	{
-		const u32 itemIndex = blockIdx.x * gNItemsPerWG + i;
-		if( itemIndex < numberOfInputs )
+		for( int i = threadIdx.x; i < BIN_SIZE; i += SORT_WG_SIZE )
 		{
-			const auto item = gSrcKey[itemIndex];
-			const u32 bucketIndex = getMaskedBits( item, START_BIT );
-			atomicInc( &localPrefixSum[bucketIndex], 0xFFFFFFFF );
+			counters[i] = 0;
+			localPrefixSum[i] = 0;
 		}
-	}
-
-	__syncthreads();
-
-	// Compute Prefix Sum
-
-	ldsScanExclusive( localPrefixSum, BIN_SIZE );
-
-	__syncthreads();
-
-	// Reorder
-
-	for( int i = threadIdx.x; i < gNItemsPerWG; i += SORT_WG_SIZE )
-	{
-		const u32 itemIndex = blockIdx.x * gNItemsPerWG + i;
-
-		const auto item = gSrcKey[itemIndex];
-		const u32 bucketIndex = getMaskedBits( item, START_BIT );
-
-		const int warp = threadIdx.x / 32;
-		const int lane = threadIdx.x % 32;
-
 		__syncthreads();
 
-		if( itemIndex < numberOfInputs )
+		for( int i = 0; i < SORT_SUBBLOCK_SIZE; i += SORT_WG_SIZE )
 		{
-			atomicOr( &matchMasks[warp][bucketIndex], 1u << lane );
-		}
-
-		__syncthreads();
-
-		bool flushMask = false;
-
-		u32 localOffset = 0;
-		u32 localSrcIndex = 0;
-
-		if( itemIndex < numberOfInputs )
-		{
-			const u32 matchMask = matchMasks[warp][bucketIndex];
-			const u32 lowerMask = ( 1u << lane ) - 1;
-			u32 offset = __popc( matchMask & lowerMask );
-
-			flushMask = ( offset == 0 );
-
-			for( int w = 0; w < warp; ++w )
+			const auto itemIndex = blockIdx.x * gNItemsPerWG + j + i + threadIdx.x;
+			if( itemIndex < numberOfInputs )
 			{
-				offset += __popc( matchMasks[w][bucketIndex] );
-			}
-
-			localOffset = counters[bucketIndex] + offset;
-			localSrcIndex = i;
-		}
-
-		__syncthreads();
-
-		if( itemIndex < numberOfInputs )
-		{
-			atomicInc( &counters[bucketIndex], 0xFFFFFFFF );
-		}
-
-		if( flushMask )
-		{
-			matchMasks[warp][bucketIndex] = 0;
-		}
-
-		// Swap
-
-		if( itemIndex < numberOfInputs )
-		{
-			const u32 srcIndex = blockIdx.x * gNItemsPerWG + localSrcIndex;
-			const u32 dstIndex = globalOffset[bucketIndex] + localOffset;
-			gDstKey[dstIndex] = gSrcKey[srcIndex];
-
-			if constexpr( KEY_VALUE_PAIR )
-			{
-				gDstVal[dstIndex] = gSrcVal[srcIndex];
+				const auto item = gSrcKey[itemIndex];
+				const u32 bucketIndex = getMaskedBits( item, START_BIT );
+				atomicInc( &localPrefixSum[bucketIndex], 0xFFFFFFFF );
+				elementBuckets[i + threadIdx.x] = static_cast<u8>(bucketIndex);
 			}
 		}
+
+		__syncthreads();
+
+		ldsScanExclusive( localPrefixSum, BIN_SIZE );
+
+		__syncthreads();
+
+		for( int i = 0; i < SORT_SUBBLOCK_SIZE; i += SORT_WG_SIZE )
+		{
+			const auto itemIndex = blockIdx.x * gNItemsPerWG + j + i + threadIdx.x;
+			const u32 bucketIndex = elementBuckets[i + threadIdx.x];
+
+			const int warp = threadIdx.x / 32;
+			const int lane = threadIdx.x % 32;
+
+			__syncthreads();
+
+			if( itemIndex < numberOfInputs )
+			{
+				atomicOr( &matchMasks[warp][bucketIndex], 1u << lane );
+			}
+
+			__syncthreads();
+
+			bool flushMask = false;
+
+			if( itemIndex < numberOfInputs )
+			{
+				const u32 matchMask = matchMasks[warp][bucketIndex];
+				const u32 lowerMask = ( 1u << lane ) - 1;
+				u32 offset = __popc( matchMask & lowerMask );
+
+				flushMask = ( offset == 0 );
+
+				for( int w = 0; w < warp; ++w )
+				{
+					offset += __popc( matchMasks[w][bucketIndex] );
+				}
+
+				const u32 localOffset = counters[bucketIndex] + offset;
+				const u32 to = localOffset + localPrefixSum[bucketIndex];
+
+				ElementLocation el;
+				el.localSrcIndex = i + threadIdx.x;
+				el.localOffset = localOffset;
+				el.bucket = bucketIndex;
+				elementLocations[to] = el;
+			}
+
+			__syncthreads();
+
+			if( itemIndex < numberOfInputs )
+			{
+				atomicInc( &counters[bucketIndex], 0xFFFFFFFF );
+			}
+
+			if( flushMask )
+			{
+				matchMasks[warp][bucketIndex] = 0;
+			}
+		}
+
+		for( int i = 0; i < SORT_SUBBLOCK_SIZE; i += SORT_WG_SIZE )
+		{
+			const int itemIndex = blockIdx.x * gNItemsPerWG + j + i + threadIdx.x;
+			if( itemIndex < numberOfInputs )
+			{
+				const auto el = elementLocations[i + threadIdx.x];
+				const auto srcIndex = blockIdx.x * gNItemsPerWG + j + el.localSrcIndex;
+				const auto bucketIndex = el.bucket;
+
+				const auto dstIndex = globalOffset[bucketIndex] + el.localOffset;
+				gDstKey[dstIndex] = gSrcKey[srcIndex];
+
+				if constexpr( KEY_VALUE_PAIR )
+				{
+					gDstVal[dstIndex] = gSrcVal[srcIndex];
+				}
+			}
+		}
+
+		__syncthreads();
+
+		for( int i = threadIdx.x; i < BIN_SIZE; i += SORT_WG_SIZE )
+		{
+			globalOffset[i] += counters[i];
+		}
+
+		__syncthreads();
 	}
 }
 


### PR DESCRIPTION
This PR implements the following:

- Use subblock for sort/reorder   (Co-authored-by: @AtsushiYoshimura0302 )
- Add "ffast-math" compiler flag.
- Bugfix: `m_is_ready` must be reset before the 1st use.
- Refactor to consider bitcode



