### PR TITLE
[ORO-0] ROCm 6 win path

### DIFF
--- a/contrib/hipew/src/hipew.cpp
+++ b/contrib/hipew/src/hipew.cpp
@@ -274,7 +274,7 @@ void hipewInit( int* resultDriver, int* resultRtc, hipuint32_t flags )
   /* Library paths. */
 #ifdef _WIN32
   /* Expected in C:/Windows/System32 or similar, no path needed. */
-  const char* hip_paths[] = {"amdhip64.dll", NULL};
+  const char* hip_paths[] = {"amdhip64_6.dll", "amdhip64.dll", NULL};
   const char* hiprtc_paths[] = {
                                 "hiprtc0605.dll",
                                 "hiprtc0604.dll",


### PR DESCRIPTION
A request from the Blender guys. The hip dll name changed to `amdhip64_6.dll`.